### PR TITLE
opti: use calldata version of verify

### DIFF
--- a/src/UniversalRewardsDistributor.sol
+++ b/src/UniversalRewardsDistributor.sol
@@ -44,7 +44,7 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor, Ownable {
     /// @param claimable The overall claimable amount of token rewards.
     /// @param proof The merkle proof that validates this claim.
     function claim(address account, address reward, uint256 claimable, bytes32[] calldata proof) external {
-        if (!MerkleProof.verify(proof, root, keccak256(abi.encodePacked(account, reward, claimable)))) {
+        if (!MerkleProof.verifyCalldata(proof, root, keccak256(abi.encodePacked(account, reward, claimable)))) {
             revert ProofInvalidOrExpired();
         }
 


### PR DESCRIPTION
As `claim` function takes `bytes32[] calldata proof` as input, using `MerkleProof.verifyCalldata` avoids copying the array to memory.