### PR TITLE
feat: add OZ merkle-tree lib compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Based on [Morpho's rewards distributor](https://github.com/morpho-dao/morpho-v1/
 
 Tests are using [Murky](https://github.com/dmfxyz/murky), to generate Merkle trees in Solidity.
 
+## Usage
+Merkle trees should be generated with [Openzeppelin library](https://github.com/OpenZeppelin/merkle-tree).  
+It will ensures trees will be secure for on-chain verification.
+
 ## Installation
 
 Download foundry:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tests are using [Murky](https://github.com/dmfxyz/murky), to generate Merkle tre
 
 ## Usage
 Merkle trees should be generated with [Openzeppelin library](https://github.com/OpenZeppelin/merkle-tree).  
-It will ensures trees will be secure for on-chain verification.
+It will ensure that trees will be secure for on-chain verification.
 
 ## Installation
 

--- a/src/UniversalRewardsDistributor.sol
+++ b/src/UniversalRewardsDistributor.sol
@@ -44,7 +44,11 @@ contract UniversalRewardsDistributor is IUniversalRewardsDistributor, Ownable {
     /// @param claimable The overall claimable amount of token rewards.
     /// @param proof The merkle proof that validates this claim.
     function claim(address account, address reward, uint256 claimable, bytes32[] calldata proof) external {
-        if (!MerkleProof.verifyCalldata(proof, root, keccak256(abi.encodePacked(account, reward, claimable)))) {
+        if (
+            !MerkleProof.verifyCalldata(
+                proof, root, keccak256(bytes.concat(keccak256(abi.encode(account, reward, claimable))))
+            )
+        ) {
             revert ProofInvalidOrExpired();
         }
 

--- a/test/UniversalRouterDistributor.t.sol
+++ b/test/UniversalRouterDistributor.t.sol
@@ -147,8 +147,12 @@ contract UniversalRouterDistributor is Test {
         uint256 i;
         while (i < size / 2) {
             uint256 index = i + 1;
-            data[i] = keccak256(abi.encodePacked(vm.addr(index), address(token1), uint256(claimable / index)));
-            data[i + 1] = keccak256(abi.encodePacked(vm.addr(index), address(token2), uint256(claimable / index)));
+            data[i] = keccak256(
+                bytes.concat(keccak256(abi.encode(vm.addr(index), address(token1), uint256(claimable / index))))
+            );
+            data[i + 1] = keccak256(
+                bytes.concat(keccak256(abi.encode(vm.addr(index), address(token2), uint256(claimable / index))))
+            );
 
             i += 2;
         }


### PR DESCRIPTION
OpenZeppelin contracts are used for on chain verification but their library to generate trees was not compatible due to the way of hashing leafs. This PR adds compatibility for the OpenZeppelin [merkle-tree lib](https://github.com/OpenZeppelin/merkle-tree).

Close #8 
