### PR TITLE
Feat/create singleton distributor

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,9 +1,8 @@
-src/=src/
 test/=test/
 
 @forge-std/=lib/forge-std/src/
 @ds-test/=lib/forge-std/lib/ds-test/src/
 
-@openzeppelin/=lib/openzeppelin-contracts/
-@solmate/=lib/solmate/
+@openzeppelin/=lib/openzeppelin-contracts/contracts/
+@solmate/=lib/solmate/src/
 @murky/=lib/murky/

--- a/src/UniversalRewardsDistributor.sol
+++ b/src/UniversalRewardsDistributor.sol
@@ -1,63 +1,236 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import {IUniversalRewardsDistributor} from "./interfaces/IUniversalRewardsDistributor.sol";
+import {IUniversalRewardsDistributor, Id} from "./interfaces/IUniversalRewardsDistributor.sol";
 
-import {ERC20, SafeTransferLib} from "@solmate/src/utils/SafeTransferLib.sol";
-
-import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {MerkleProof} from "@openzeppelin/utils/cryptography/MerkleProof.sol";
+import {Ownable} from "@openzeppelin/access/Ownable.sol";
+import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
+import {ERC20} from "@openzeppelin/token/ERC20/ERC20.sol";
 
 /// @title UniversalRewardsDistributor
 /// @author MerlinEgalite
 /// @notice This contract allows to distribute different rewards tokens to multiple accounts using a Merkle tree.
 ///         It is largely inspired by Morpho's current rewards distributor:
 ///         https://github.com/morpho-dao/morpho-v1/blob/main/src/common/rewards-distribution/RewardsDistributor.sol
-contract UniversalRewardsDistributor is IUniversalRewardsDistributor, Ownable {
+contract UniversalRewardsDistributor is IUniversalRewardsDistributor {
     using SafeTransferLib for ERC20;
 
     /* STORAGE */
+    address public immutable IS_PERMISSIONED;
 
-    /// @notice The merkle tree's root of the current rewards distribution.
-    bytes32 public root;
+    /// @notice The merkle tree's roots of a given distribution.
+    mapping(Id => bytes32) public roots;
 
-    /// @notice The `amount` of `reward` token already claimed by `account`.
-    mapping(address account => mapping(address reward => uint256 amount)) public claimed;
+    /// @notice The `amount` of `reward` token already claimed by `account` for one given distribution.
+    mapping(Id => mapping(address account => mapping(address reward => uint256 amount))) public claimed;
 
+    /// @notice The treasury address of a given distribution.
+    /// @dev The treasury is the address from which the rewards are sent by using a classic approval.
+    mapping(Id => address) public treasuries;
+
+    /// @notice The address that can update the distributions parameters, and freeze a root.
+    mapping(Id => address) public rootOwner;
+
+    /// @notice The addresses that can update the merkle tree's root for a given distribution.
+    mapping(Id => mapping(address => bool)) public rootUpdaters;
+
+    /// @notice The timelock for a given distribution.
+    mapping(Id => uint256) public timelocks;
+
+    /// @notice The pending root for a given distribution.
+    /// @dev If the pending root is set, the root can be updated after the timelock has expired.
+    /// @dev The pending root is skipped if the timelock is set to 0.
+    mapping(Id => PendingRoot) public pendingRoots;
+
+    /// @notice The pending treasury for a given distribution.
+    /// @dev The pending treasury has to accept the treasury role to become the new treasury.
+    mapping(Id => address) public pendingTreasuries;
+
+    /// @notice The frozen status of a given distribution.
+    /// @dev A frozen distribution cannot be claimed by users.
+    mapping(Id => bool) public frozen;
+
+    modifier onlyUpdater(Id id) {
+        require(
+            rootUpdaters[id][msg.sender] || msg.sender == rootOwner[id],
+            "UniversalRewardsDistributor: caller is not the updater"
+        );
+        _;
+    }
+
+    modifier onlyTreasury(Id id) {
+        require(msg.sender == treasuries[id], "UniversalRewardsDistributor: caller is not the treasury");
+        _;
+    }
+
+    modifier onlyOwner(Id id) {
+        require(msg.sender == rootOwner[id], "UniversalRewardsDistributor: caller is not the owner");
+        _;
+    }
+
+    modifier notFrozen(Id id) {
+        require(!frozen[id], "UniversalRewardsDistributor: frozen");
+        _;
+    }
+
+    modifier isCreationAllowed() {
+        require(
+            IS_PERMISSIONED == address(0) || msg.sender == IS_PERMISSIONED,
+            "UniversalRewardsDistributor: creation not allowed"
+        );
+        _;
+    }
+
+    /// @notice The constructor of the contract.
+    /// @param isPermissionLess Whether the contract is permissionLess or not.
+    constructor(bool isPermissionLess) {
+        if (!isPermissionLess) {
+            IS_PERMISSIONED = msg.sender;
+        }
+    }
     /* EXTERNAL */
 
     /// @notice Updates the current merkle tree's root.
     /// @param newRoot The new merkle tree's root.
-    function updateRoot(bytes32 newRoot) external onlyOwner {
-        root = newRoot;
-        emit RootUpdated(newRoot);
+    function proposeRoot(Id id, bytes32 newRoot) external onlyUpdater(id) {
+        if (timelocks[id] == 0) {
+            roots[id] = newRoot;
+            delete pendingRoots[id];
+            emit RootUpdated(id, newRoot);
+        }
+        pendingRoots[id] = PendingRoot(block.timestamp, newRoot);
+        emit RootSubmitted(id, newRoot);
     }
 
-    /// @notice Transfers the `token` balance from this contract to the owner.
-    function skim(address token) external onlyOwner {
-        ERC20(token).safeTransfer(msg.sender, ERC20(token).balanceOf(address(this)));
+    /// @notice Updates the current merkle tree's root.
+    /// @param id The id of the merkle tree distribution.
+    /// @dev This function can only be called after the timelock has expired.
+    /// @dev Anyone can call this function.
+    function confirmRootUpdate(Id id) external {
+        require(pendingRoots[id].submittedAt > 0, "UniversalRewardsDistributor: no pending root");
+        require(
+            block.timestamp >= pendingRoots[id].submittedAt + timelocks[id],
+            "UniversalRewardsDistributor: timelock not expired"
+        );
+        roots[id] = pendingRoots[id].root;
+        delete pendingRoots[id];
+        emit RootUpdated(id, pendingRoots[id].root);
     }
 
     /// @notice Claims rewards.
+    /// @param id The id of the merkle tree distribution.
     /// @param account The address to claim rewards for.
     /// @param reward The address of the reward token.
     /// @param claimable The overall claimable amount of token rewards.
     /// @param proof The merkle proof that validates this claim.
-    function claim(address account, address reward, uint256 claimable, bytes32[] calldata proof) external {
-        if (
-            !MerkleProof.verifyCalldata(
-                proof, root, keccak256(bytes.concat(keccak256(abi.encode(account, reward, claimable))))
-            )
-        ) {
-            revert ProofInvalidOrExpired();
+    function claim(Id id, address account, address reward, uint256 claimable, bytes32[] calldata proof)
+        external
+        notFrozen(id)
+    {
+        require(roots[id] != bytes32(0), "UniversalRewardsDistributor: root is not set");
+
+        require(
+            MerkleProof.verifyCalldata(
+                proof, roots[id], keccak256(bytes.concat(keccak256(abi.encode(account, reward, claimable))))
+            ),
+            "UniversalRewardsDistributor: invalid proof or expired"
+        );
+
+        uint256 amount = claimable - claimed[id][account][reward];
+
+        require(amount > 0, "UniversalRewardsDistributor: already claimed");
+
+        claimed[id][account][reward] = claimable;
+
+        ERC20(reward).safeTransferFrom(treasuries[id], account, amount);
+        emit RewardsClaimed(id, account, reward, amount);
+    }
+
+    /// @notice Creates a new distribution.
+    /// @param initialTimelock The initial timelock for the new distribution.
+    /// @param initialRoot The initial merkle tree's root for the new distribution.
+    /// @dev The caller of this function is the owner and the treasury of the new distribution.
+    function createDistribution(uint256 initialTimelock, bytes32 initialRoot) external isCreationAllowed {
+        Id id = Id.wrap(keccak256(abi.encode(msg.sender, block.timestamp)));
+        rootOwner[id] = msg.sender;
+        treasuries[id] = msg.sender;
+        timelocks[id] = initialTimelock;
+        roots[id] = initialRoot;
+
+        emit DistributionCreated(id, msg.sender, initialTimelock);
+        if (initialRoot != bytes32(0)) {
+            emit RootUpdated(id, initialRoot);
         }
+    }
 
-        uint256 amount = claimable - claimed[account][reward];
-        if (amount == 0) revert AlreadyClaimed();
+    /// @notice Submits a new treasury address for a given distribution.
+    /// @param id The id of the merkle tree distribution.
+    /// @param newTreasury The new treasury address.
+    function suggestTreasury(Id id, address newTreasury) external onlyOwner(id) {
+        pendingTreasuries[id] = newTreasury;
+        emit TreasurySuggested(id, newTreasury);
+    }
 
-        claimed[account][reward] = claimable;
+    /// @notice Accepts the treasury role for a given distribution.
+    /// @param id The id of the merkle tree distribution.
+    function acceptAsTreasury(Id id) external {
+        require(msg.sender = pendingTreasuries[id], "UniversalRewardsDistributor: caller is not the pending treasury");
+        treasuries[id] = pendingTreasuries[id];
+        delete pendingTreasuries[id];
+        emit TreasuryUpdated(id, treasuries[id]);
+    }
 
-        ERC20(reward).safeTransfer(account, amount);
-        emit RewardsClaimed(account, reward, amount);
+    /// @notice Freeze a given distribution.
+    /// @param id The id of the merkle tree distribution.
+    /// @param isFrozen Whether the distribution should be frozen or not.
+    function freeze(Id id, bool isFrozen) external onlyOwner(id) {
+        frozen[id] = isFrozen;
+        emit Frozen(id, isFrozen);
+    }
+
+    /// @notice Force update the root of a given distribution.
+    /// @param id The id of the merkle tree distribution.
+    /// @param newRoot The new merkle tree's root.
+    /// @dev This function can only be called by the owner of the distribution.
+    /// @dev The distribution must be frozen before.
+    function forceUpdateRoot(Id id, bytes32 newRoot) external onlyOwner(id) {
+        require(frozen[id], "UniversalRewardsDistributor: not frozen");
+        roots[id] = newRoot;
+        emit RootUpdated(id, newRoot);
+    }
+
+    /// @notice Update the timelock of a given distribution.
+    /// @param id The id of the merkle tree distribution.
+    /// @param newTimelock The new timelock.
+    /// @dev This function can only be called by the owner of the distribution.
+    /// @dev If the timelock is reduced, it can only be updated after the timelock has expired.
+    function updateTimelock(Id id, uint256 newTimelock) external onlyOwner(id) {
+        if(newTimelock < timelocks[id]) {
+            require(
+                pendingRoots[id].submittedAt == 0 || pendingRoots[id].submittedAt + timelocks[id] <= block.timestamp,
+                "UniversalRewardsDistributor: timelock not expired"
+            );
+        }
+        timelocks[id] = newTimelock;
+        emit TimelockUpdated(id, newTimelock);
+    }
+
+    /// @notice Update the root updater of a given distribution.
+    /// @param id The id of the merkle tree distribution.
+    /// @param updater The new root updater.
+    /// @param active Whether the root updater should be active or not.
+    function editRootUpdater(Id id, address updater, bool active) external onlyOwner(id) {
+        rootUpdaters[id][updater] = active;
+        emit RootUpdaterUpdated(id, updater, active);
+    }
+
+    /// @notice Revoke the pending root of a given distribution.
+    /// @param id The id of the merkle tree distribution.
+    /// @dev This function can only be called by the owner of the distribution at any time.
+    function revokePendingRoot(Id id) external onlyOwner(id) {
+        require(pendingRoots[id].submittedAt != 0, "UniversalRewardsDistributor: no pending root");
+        delete pendingRoots[id];
+        emit PendingRootRevoked(id);
     }
 }

--- a/src/UniversalRewardsDistributor.sol
+++ b/src/UniversalRewardsDistributor.sol
@@ -9,8 +9,8 @@ import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
 import {ERC20} from "@openzeppelin/token/ERC20/ERC20.sol";
 
 /// @title UniversalRewardsDistributor
-/// @author MerlinEgalite
-/// @notice This contract allows to distribute different rewards tokens to multiple accounts using a Merkle tree.
+/// @author Morpho Labs
+/// @notice This contract allows to distribute different rewards tokens to multiple accounts using different Merkle tree.
 ///         It is largely inspired by Morpho's current rewards distributor:
 ///         https://github.com/morpho-dao/morpho-v1/blob/main/src/common/rewards-distribution/RewardsDistributor.sol
 contract UniversalRewardsDistributor is IUniversalRewardsDistributor {

--- a/src/interfaces/IUniversalRewardsDistributor.sol
+++ b/src/interfaces/IUniversalRewardsDistributor.sol
@@ -4,18 +4,19 @@ pragma solidity >=0.5.0;
 type Id is bytes32;
 
 /// @title IUniversalRewardsDistributor
-/// @author MerlinEgalite
+/// @author Morpho Labs
 /// @notice UniversalRewardsDistributor's interface.
 interface IUniversalRewardsDistributor {
 
+    /// @notice The pending root struct for a merkle tree distribution during the timelock.
     struct PendingRoot {
+        /// @dev The block timestamp of the pending root submission.
         uint256 submittedAt;
+        /// @dev The submitted pending root.
         bytes32 root;
     }
 
-
     /* EVENTS */
-
 
     /// @notice Emitted when the merkle tree's root is updated.
     /// @param treeId The id of the merkle tree distribution.
@@ -27,20 +28,45 @@ interface IUniversalRewardsDistributor {
     event RootSubmitted(Id indexed treeId, bytes32 newRoot);
 
 
+    /// @notice Emitted when a new Treasury.
+    /// @param treeId The id of the merkle tree distribution.
+    /// @param newTreasury The new merkle tree's treasury where rewards are pulled from.
     event TreasuryUpdated(Id indexed treeId, address newTreasury);
+
+    /// @notice Emitted when a new merkle tree's treasury is suggested by the owner.
+    /// @param treeId The id of the merkle tree distribution.
+    /// @param newTreasury The new treasury that needs to approve the change.
     event TreasurySuggested(Id indexed treeId, address newTreasury);
 
+
+    /// @notice Emitted when a merkle tree is frozen or unfrozen by the owner.
+    /// @param treeId The id of the merkle tree distribution.
+    /// @param frozen The new merkle tree's frozen state.
     event Frozen(Id indexed treeId, bool frozen);
 
+    /// @notice Emitted when a merkle tree distribution timelock is modified.
+    /// @param treeId The id of the merkle tree distribution.
+    /// @param timelock The new merkle tree's timelock.
     event TimelockUpdated(Id indexed treeId, uint256 timelock);
 
+    /// @notice Emitted when a merkle tree distribution is created.
+    /// @param treeId The id of the merkle tree distribution.
+    /// @param owner The owner of the merkle tree distribution.
+    /// @param initialTimelock The initial timelock of the merkle tree distribution.
     event DistributionCreated(Id indexed treeId, address indexed owner, uint256 initialTimelock);
 
+    /// @notice Emitted when a merkle tree updater is added or removed.
+    /// @param treeId The id of the merkle tree distribution.
+    /// @param rootUpdater The merkle tree updater.
+    /// @param active The merkle tree updater's active state.
     event RootUpdaterUpdated(Id indexed treeId, address indexed rootUpdater, bool active);
 
+    /// @notice Emitted when a merkle tree's pending root is revoked.
+    /// @param treeId The id of the merkle tree distribution.
     event PendingRootRevoked(Id indexed treeId);
 
     /// @notice Emitted when rewards are claimed.
+    /// @param treeId The id of the merkle tree distribution.
     /// @param account The address for which rewards are claimd rewards for.
     /// @param reward The address of the reward token.
     /// @param amount The amount of reward token claimed.

--- a/src/interfaces/IUniversalRewardsDistributor.sol
+++ b/src/interfaces/IUniversalRewardsDistributor.sol
@@ -1,35 +1,63 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
+type Id is bytes32;
+
 /// @title IUniversalRewardsDistributor
 /// @author MerlinEgalite
 /// @notice UniversalRewardsDistributor's interface.
 interface IUniversalRewardsDistributor {
+
+    struct PendingRoot {
+        uint256 submittedAt;
+        bytes32 root;
+    }
+
+
     /* EVENTS */
 
+
     /// @notice Emitted when the merkle tree's root is updated.
+    /// @param treeId The id of the merkle tree distribution.
     /// @param newRoot The new merkle tree's root.
-    event RootUpdated(bytes32 newRoot);
+    event RootUpdated(Id indexed treeId, bytes32 newRoot);
+
+    /// @notice Emitted when a new merkle tree's root is submitted.
+    /// @param newRoot The new merkle tree's root.
+    event RootSubmitted(Id indexed treeId, bytes32 newRoot);
+
+
+    event TreasuryUpdated(Id indexed treeId, address newTreasury);
+    event TreasurySuggested(Id indexed treeId, address newTreasury);
+
+    event Frozen(Id indexed treeId, bool frozen);
+
+    event TimelockUpdated(Id indexed treeId, uint256 timelock);
+
+    event DistributionCreated(Id indexed treeId, address indexed owner, uint256 initialTimelock);
+
+    event RootUpdaterUpdated(Id indexed treeId, address indexed rootUpdater, bool active);
+
+    event PendingRootRevoked(Id indexed treeId);
 
     /// @notice Emitted when rewards are claimed.
     /// @param account The address for which rewards are claimd rewards for.
     /// @param reward The address of the reward token.
     /// @param amount The amount of reward token claimed.
-    event RewardsClaimed(address account, address reward, uint256 amount);
-
-    /* ERRORS */
-
-    /// @notice Thrown when the merkle proof is invalid or expired.
-    error ProofInvalidOrExpired();
-
-    /// @notice Thrown when the rewards have already been claimed.
-    error AlreadyClaimed();
+    event RewardsClaimed(Id indexed treeId, address indexed account, address indexed reward, uint256 amount);
 
     /* EXTERNAL */
 
-    function updateRoot(bytes32 newRoot) external;
-
-    function skim(address token) external;
-
-    function claim(address account, address reward, uint256 claimable, bytes32[] calldata proof) external;
+    function proposeRoot(Id id, bytes32 newRoot) external;
+    function confirmRootUpdate(Id id) external;
+    function claim(Id id, address account, address reward, uint256 claimable, bytes32[] calldata proof)
+    external;
+    function createDistribution(uint256 initialTimelock, bytes32 initialRoot) external;
+    function suggestTreasury(Id id, address newTreasury) external;
+    function acceptAsTreasury(Id id) external;
+    function freeze(Id id, bool isFrozen) external;
+    function forceUpdateRoot(Id id, bytes32 newRoot) external;
+    function updateTimelock(Id id, uint256 newTimelock) external;
+    function editRootUpdater(Id id, address updater, bool active) external;
+    function revokePendingRoot(Id id) external;
 }

--- a/test/UniversalRouterDistributor.t.sol
+++ b/test/UniversalRouterDistributor.t.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import "@solmate/src/test/utils/mocks/MockERC20.sol";
-import "src/UniversalRewardsDistributor.sol";
+import {MockERC20} from "@solmate/test/utils/mocks/MockERC20.sol";
+import {UniversalRewardsDistributor} from "src/UniversalRewardsDistributor.sol";
+import {IUniversalRewardsDistributor} from "src/interfaces/IUniversalRewardsDistributor.sol";
+import {ERC20} from "@openzeppelin/token/ERC20/ERC20.sol";
 
 import {Merkle} from "@murky/src/Merkle.sol";
 


### PR DESCRIPTION
## Pull request

## Scopes
- create a singleton merkle tree distributor that is using approvals to distribute tokens.
- The market creation can be permissionned or not. So an integrator can deploy his own rewards distributor or reuse the DAO one (if any).

> **Warning**  
> This is a POC and it shoud not be merged without testing
